### PR TITLE
composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,11 @@
         "kirby3-cms",
         "kirby3-plugin"
     ],
+    "autoload": {
+        "files": [
+            "src/SendMentions.php"
+        ]
+    },
     "require": {
         "getkirby/composer-installer": "^1.1"
     }


### PR DESCRIPTION
Could you please add this to packagist? This way it would be possible to install the plugin via composer. 

@see https://getkirby.com/docs/guide/plugins/plugin-setup-basic#publish-your-plugin